### PR TITLE
Return Promise instead of Rust Future in fluvio client wrappers.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2,16 +2,15 @@ import("../pkg").then(async fluvioWasm => {
   var Fluvio = fluvioWasm.Fluvio;
   var Offset = fluvioWasm.Offset;
   const fluvio = await Fluvio.connect("ws://localhost:3000")
-  const fluvio_2 = await Fluvio.connect("ws://localhost:3000")
-  const producer = await fluvio_2.topic_producer("foobar");
+  const producer = await fluvio.topicProducer("foobar");
   await producer.send("", `count`);
 
-  const consumer = await fluvio.partition_consumer("foobar", 0);
-  let stream = await consumer.stream(Offset.from_end(10))
+  const consumer = await fluvio.partitionConsumer("foobar", 0);
+  let stream = await consumer.stream(Offset.fromEnd(10))
 
   let count = 0;
   let before = new Date();
-  while (count < 1000) {
+  while (count < 10) {
 
     await producer.send("", `count-${count}`);
     let next = await stream.next();

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -17,7 +17,8 @@ pub struct FluvioAdmin {
 }
 #[wasm_bindgen]
 impl FluvioAdmin {
-    pub fn list_topic(&mut self) -> Promise {
+    #[wasm_bindgen(js_name = listTopics)]
+    pub fn list_topics(&mut self) -> Promise {
         let rc = self.inner.clone();
         future_to_promise(async move {
             let topic_list = rc
@@ -37,7 +38,8 @@ impl FluvioAdmin {
         })
     }
 
-    pub fn list_partition(&mut self) -> Promise {
+    #[wasm_bindgen(js_name = listPartitions)]
+    pub fn list_partitions(&mut self) -> Promise {
         let rc = self.inner.clone();
         future_to_promise(async move {
             let partition_list = rc

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -1,40 +1,67 @@
+use std::rc::Rc;
+
+use js_sys::Promise;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::future_to_promise;
+
+use fluvio::{config::FluvioConfig, Fluvio as NativeFluvio};
 
 use crate::{FluvioAdmin, FluvioError, FluvioWebsocketConnector, PartitionConsumer, TopicProducer};
-use fluvio::{config::FluvioConfig, Fluvio as NativeFluvio};
 
 #[wasm_bindgen]
 pub struct Fluvio {
-    inner: NativeFluvio,
+    inner: Rc<NativeFluvio>,
 }
 
 #[wasm_bindgen]
 impl Fluvio {
-    pub async fn topic_producer(self, topic: String) -> Result<TopicProducer, FluvioError> {
-        Ok(self.inner.topic_producer(topic).await?.into())
+    pub fn topic_producer(&self, topic: String) -> Promise {
+        let rc = self.inner.clone();
+
+        future_to_promise(async move {
+            let topic_producer = rc
+                .topic_producer(topic)
+                .await
+                .map(|producer| JsValue::from(TopicProducer::from(producer)))
+                .map_err(|e| FluvioError::from(e).into());
+
+            topic_producer
+        })
     }
-    pub async fn partition_consumer(
-        self,
-        topic: String,
-        partition: i32,
-    ) -> Result<PartitionConsumer, FluvioError> {
-        Ok(self
-            .inner
-            .partition_consumer(topic, partition)
-            .await?
-            .into())
+    #[wasm_bindgen(js_name = partitionConsumer)]
+    pub fn partition_consumer(&self, topic: String, partition: i32) -> Promise {
+        let rc = self.inner.clone();
+        future_to_promise(async move {
+            let partition_consumer = rc
+                .partition_consumer(topic, partition)
+                .await
+                .map(|consumer| JsValue::from(PartitionConsumer::from(consumer)))
+                .map_err(|e| FluvioError::from(e).into());
+
+            partition_consumer
+        })
     }
+
     pub async fn connect(addr: String) -> Result<Fluvio, FluvioError> {
         crate::utils::set_panic_hook();
+
         let config = FluvioConfig::new(addr);
-        let inner = NativeFluvio::connect_with_connector(
-            Box::new(FluvioWebsocketConnector::new()),
-            &config,
-        )
-        .await?;
+
+        let inner = Rc::new(
+            NativeFluvio::connect_with_connector(
+                Box::new(FluvioWebsocketConnector::new()),
+                &config,
+            )
+            .await?,
+        );
         Ok(Self { inner })
     }
-    pub async fn admin(self) -> FluvioAdmin {
-        self.inner.admin().await.into()
+    pub fn admin(&self) -> Promise {
+        let rc = self.inner.clone();
+        future_to_promise(async move {
+            let admin = JsValue::from(FluvioAdmin::from(rc.admin().await));
+
+            Ok(admin)
+        })
     }
 }

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -15,6 +15,7 @@ pub struct Fluvio {
 
 #[wasm_bindgen]
 impl Fluvio {
+    #[wasm_bindgen(js_name = topicProducer)]
     pub fn topic_producer(&self, topic: String) -> Promise {
         let rc = self.inner.clone();
 

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -8,12 +8,15 @@ pub struct Offset {
 
 #[wasm_bindgen]
 impl Offset {
+    #[wasm_bindgen(js_name = fromBeginning)]
     pub fn from_beginning(offset: u32) -> Self {
         NativeOffset::from_beginning(offset).into()
     }
     pub fn beginning() -> Self {
         NativeOffset::beginning().into()
     }
+
+    #[wasm_bindgen(js_name = fromEnd)]
     pub fn from_end(offset: u32) -> Self {
         NativeOffset::from_end(offset).into()
     }

--- a/src/record.rs
+++ b/src/record.rs
@@ -10,14 +10,17 @@ impl Record {
     pub fn value(&self) -> Vec<u8> {
         self.inner.value().to_vec()
     }
-    pub fn valueString(&self) -> Option<String> {
+    #[wasm_bindgen(js_name = valueString)]
+    pub fn value_string(&self) -> Option<String> {
         String::from_utf8(self.inner.value().to_vec()).ok()
     }
 
     pub fn key(&self) -> Option<Vec<u8>> {
         self.inner.key().map(|v| v.to_vec())
     }
-    pub fn keyString(&self) -> Option<String> {
+
+    #[wasm_bindgen(js_name = keyString)]
+    pub fn key_string(&self) -> Option<String> {
         if let Some(key) = self.key() {
             String::from_utf8(key.to_vec()).ok()
         } else {

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -12,9 +12,8 @@ pub struct TopicMetadata {
 
 #[wasm_bindgen]
 impl TopicMetadata {
-
     #[wasm_bindgen(method, getter)]
-        pub fn name(&self) -> String {
+    pub fn name(&self) -> String {
         self.inner.name.clone()
     }
 


### PR DESCRIPTION
This is done in order to be able to reuse a connection for multiple purposes.

With this change, all the things that we have in tests/web.rs does not compile. I am not sure how to turn a Promise into a Rust struct. I am able to convert that into a JsValue but not into a Rust struct.
