### PR TITLE
Export types

### DIFF
--- a/Cargo.toml.d.ts
+++ b/Cargo.toml.d.ts
@@ -1,5 +1,5 @@
-export * from "../target/wasm-pack/fluvio-client-wasm/index";
+export * from "./target/wasm-pack/fluvio-client-wasm/index";
 
-type Exports = typeof import("../target/wasm-pack/fluvio-client-wasm/index");
+type Exports = typeof import("./target/wasm-pack/fluvio-client-wasm/index");
 declare const init: () => Promise<Exports>;
 export default init;

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+export * from "./Cargo.toml";
+
 import init from "./Cargo.toml";
 
 export default init;

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "copy-webpack-plugin": "^5.0.3",
     "rimraf": "^3.0.0",
     "rollup": "^2.50.2",
+    "rollup-plugin-dts": "3",
     "tslib": "^2.2.0",
-    "typescript": "^3.9.0",
+    "typescript": "4",
     "webpack": "^4.42.0",
     "webpack-cli": "^3.3.3",
     "webpack-dev-server": "^3.7.2"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,18 +1,28 @@
 import rust from "@wasm-tool/rollup-plugin-rust";
 import typescript from "@rollup/plugin-typescript";
+import dts from "rollup-plugin-dts";
 
-export default {
+const config = [
+  {
     input: "index.ts",
     output: {
-        file: "dist/fluvio-client.js",
-        format: "umd",
-        sourcemap: true,
-	name: "fluvio",
+      file: "dist/fluvio-client.js",
+      format: "umd",
+      sourcemap: true,
+      name: "fluvio",
     },
     plugins: [
-        rust({
-	    watchPatterns: ["src/**"],
-	}),
-	typescript()
+      rust({
+	  serverPath: "/",
+      }),
+      typescript(),
     ],
-};
+  },
+  {
+    input: "index.ts",
+    output: [{ file: "dist/fluvio-client.d.ts", format: "es" }],
+    plugins: [rust(), dts()],
+  },
+];
+
+export default config;


### PR DESCRIPTION
 With this change, we  export the types in the bundle (a d.ts file) so we can use them in typescript projects. This was inspired by https://medium.com/@martin_hotell/typescript-library-tips-rollup-your-types-995153cc81c7