### PR TITLE
Added getters in FluvioError and made example js use it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ build-dev:
 test: install-wasm-pack
 	wasm-pack test --firefox --headless
 
-fluvio-websocket-proxy:
-	cargo run -- ./fluvio-websocket-proxy/Cargo.toml
+run-fluvio-websocket-proxy:
+	cargo run --manifest-path ./fluvio-websocket-proxy/Cargo.toml
 
 webpack-dev:
 	npm install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is currently setup to be used via rollup.
 Setup fluvio with a `--local` cluster installation locally then run the
 following:
 
-* `make fluvio-websocket-proxy`
+* `make run-fluvio-websocket-proxy`
 
 ### Hot Reloading
 To use hotreloading for the contents of

--- a/js/index.js
+++ b/js/index.js
@@ -1,22 +1,53 @@
 import("../pkg").then(async fluvioWasm => {
   var Fluvio = fluvioWasm.Fluvio;
   var Offset = fluvioWasm.Offset;
-  const fluvio = await Fluvio.connect("ws://localhost:3000")
-  const producer = await fluvio.topicProducer("foobar");
-  await producer.send("", `count`);
+  while (true) {
+    try {
+      const fluvio = await Fluvio.connect("ws://localhost:3000")
+      const producer = await fluvio.topicProducer("foobar");
+      await producer.send("", `count`);
 
-  const consumer = await fluvio.partitionConsumer("foobar", 0);
-  let stream = await consumer.stream(Offset.fromEnd(10))
+      const consumer = await fluvio.partitionConsumer("foobar", 0);
+      let stream = await consumer.stream(Offset.fromEnd(1))
+      const userAgent = navigator.userAgent;
 
-  let count = 0;
-  let before = new Date();
-  while (count < 10) {
+      let count = 0;
+      let before = new Date();
+      while (count < 10000) {
 
-    await producer.send("", `count-${count}`);
-    let next = await stream.next();
-    console.log(`${next.keyString()} - ${next.valueString()}`);
-    count++;
+        try {
+          await producer.send("", `${count}-${userAgent}`);
+          let next = await stream.next();
+          let text = `${next.valueString()}`;
+          console.log(text);
+          document.body.innerHTML =
+            `<div>${text}</div>` +
+            document.body.innerHTML;
+          count++;
+        } catch (e) {
+          console.error(e);
+          console.error(e.message);
+          console.error(e.stack);
+          let text = `${e} - ${userAgent}`;
+          document.body.innerHTML =
+            `<div>${text}</div>` +
+            document.body.innerHTML;
+          break;
+        }
+        await sleep(50);
+      }
+      let after = new Date();
+      console.log(`The recieved ${count} in took ${after - before} ms`);
+    } catch (e) {
+      console.error(e);
+      console.error(e.message);
+      console.error(e.stack);
+      break;
+    }
+    await sleep(5000);
   }
-  let after = new Date();
-  console.log(`The recieved ${count} in took ${after - before} ms`);
 });
+
+const sleep = (milliseconds) => {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,34 @@ pub struct FluvioError {
     inner: NativeFluvioError,
 }
 
+// This is to get the stack for `FluvioError`
+#[wasm_bindgen]
+extern "C" {
+    type Error;
+
+    #[wasm_bindgen(constructor)]
+    fn new() -> Error;
+
+    #[wasm_bindgen(structural, method, getter)]
+    fn stack(error: &Error) -> String;
+}
+#[wasm_bindgen]
+impl FluvioError {
+    #[wasm_bindgen(getter)]
+    pub fn message(&self) -> String {
+        format!("{:?}", self.inner)
+    }
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        format!("FluvioError")
+    }
+    #[wasm_bindgen(getter)]
+    pub fn stack(&self) -> String {
+        let e = Error::new();
+        e.stack()
+    }
+}
+
 impl From<NativeFluvioError> for FluvioError {
     fn from(inner: NativeFluvioError) -> Self {
         Self { inner }


### PR DESCRIPTION
Part of #28.

This exposes the message, name and stack for the `FluvioError` wrapper.

I've also updated the example for it.

I've tested this across three browsers (ff 89, ff 90 and chromium). With my local setup, the websocket never dies, when I move to a different tab, the timeout goes from 50ms to ~500ms. I think that's just due to the js runtime when the tab is in the background.

I've tested that the try-catch logic works by starting all the browsers and then killing the websocket proxy. It's pretty instant in ff 90 and chromium but takes upwards of 10 seconds in ff 89. Not sure what's up with that.

Anyway, for now we can use try-catch.