### PR TITLE
Made tests not require passing in Fluvio instance.

### DIFF
--- a/tests/js/simple/simple.js
+++ b/tests/js/simple/simple.js
@@ -1,3 +1,6 @@
+import { Offset, Fluvio } from '../../../../../wasm-bindgen-test';
+
+
 const createUUID = () => {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
@@ -5,18 +8,22 @@ const createUUID = () => {
   });
 };
 const topic = createUUID();
-export const setup = async (fluvio) => {
+
+var fluvio;
+export const setup = async () => {
+  fluvio  = await Fluvio.connect("ws://localhost:3000");
   const admin = await fluvio.admin();
   await admin.createTopic(topic, 1);
 }
-export const teardown = async (fluvio) => {
+export const teardown = async () => {
   const admin = await fluvio.admin();
   await admin.deleteTopic(topic);
 }
 
-export const test = async (fluvio, offset) => {
+export const test = async () => {
   const producer = await fluvio.topicProducer(topic);
   await producer.send("", `count`);
+  const offset = Offset.fromEnd(1);
 
   const consumer = await fluvio.partitionConsumer(topic, 0);
   let stream = await consumer.stream(offset); // this is a work around as Offset is not in scope.

--- a/tests/js/simple/simple.js
+++ b/tests/js/simple/simple.js
@@ -1,6 +1,5 @@
 import { Offset, Fluvio } from '../../../../../wasm-bindgen-test';
 
-
 const createUUID = () => {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);

--- a/tests/js_tests.rs
+++ b/tests/js_tests.rs
@@ -5,16 +5,8 @@ use std::convert::TryFrom;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
-pub use fluvio_client_wasm::*;
+pub use fluvio_client_wasm::FluvioError;
 
-async fn get_fluvio() -> Fluvio {
-    let fluvio = Fluvio::connect("ws://localhost:3000".into()).await;
-    if let Err(e) = fluvio {
-        let e = FluvioError::try_from(e);
-        panic!("{:?}", e);
-    }
-    fluvio.unwrap()
-}
 
 #[wasm_bindgen_test]
 async fn simple() {
@@ -22,24 +14,24 @@ async fn simple() {
     extern "C" {
 
         #[wasm_bindgen(catch)]
-        pub async fn setup(fluvio: Fluvio) -> Result<JsValue, JsValue>;
+        pub async fn setup() -> Result<JsValue, JsValue>;
 
         #[wasm_bindgen(catch)]
-        pub async fn test(fluvio: Fluvio, offset: Offset) -> Result<JsValue, JsValue>;
+        pub async fn test() -> Result<JsValue, JsValue>;
 
         #[wasm_bindgen(catch)]
-        pub async fn teardown(fluvio: Fluvio) -> Result<JsValue, JsValue>;
+        pub async fn teardown() -> Result<JsValue, JsValue>;
     }
 
-    setup(get_fluvio().await)
+    setup()
         .await
         .map_err(FluvioError::try_from)
         .expect("Setup failed");
-    test(get_fluvio().await, Offset::from_end(1))
+    test()
         .await
         .map_err(FluvioError::try_from)
         .expect("Test failed");
-    teardown(get_fluvio().await)
+    teardown()
         .await
         .map_err(FluvioError::try_from)
         .expect("Teardown failed");

--- a/tests/js_tests.rs
+++ b/tests/js_tests.rs
@@ -7,7 +7,6 @@ use wasm_bindgen::JsValue;
 
 pub use fluvio_client_wasm::FluvioError;
 
-
 #[wasm_bindgen_test]
 async fn simple() {
     #[wasm_bindgen(module = "/tests/js/simple/simple.js")]


### PR DESCRIPTION
This isn't a documented feature of wasm-bindgen but I finally figured out how to fully end to end test the JS as a user of the client.