### PR TITLE
Downgrade wasm-pack version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-      - name: Check yarn
+      - name: install yarn packages
         run: yarn install
-      - run: yarn pack
+      - name: try to pack package
+        run: yarn pack
 
   smoke_test:
     name: Run tests against fluvio cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Check yarn
-        run: |
-          yarn install
-          yarn build
+        run: yarn install
+      - run: yarn pack
 
   smoke_test:
     name: Run tests against fluvio cluster

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-dts": "^4.1",
     "tslib": "^2.2.0",
     "typescript": "^4.5.4",
-    "wasm-pack": "^0.10.2",
+    "wasm-pack": "^0.10.1",
     "webpack": "^5.66.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,7 +52,7 @@ __metadata:
     rollup-plugin-dts: ^4.1
     tslib: ^2.2.0
     typescript: ^4.5.4
-    wasm-pack: ^0.10.2
+    wasm-pack: ^0.10.1
     webpack: ^5.66.0
     webpack-cli: ^4.9.1
     webpack-dev-server: ^4.7.3
@@ -3765,7 +3765,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wasm-pack@npm:^0.10.0":
+"wasm-pack@npm:^0.10.0, wasm-pack@npm:^0.10.1":
   version: 0.10.1
   resolution: "wasm-pack@npm:0.10.1"
   dependencies:
@@ -3773,17 +3773,6 @@ __metadata:
   bin:
     wasm-pack: run.js
   checksum: ed4b6888798cee1613ae56e65a1256bd2c98ebd2c3e90a74332c8ad6c9c863f7159ed6c7bbf157b830e9ca1444d249b3cb508bbebe6303259b957ec71b6d2831
-  languageName: node
-  linkType: hard
-
-"wasm-pack@npm:^0.10.2":
-  version: 0.10.2
-  resolution: "wasm-pack@npm:0.10.2"
-  dependencies:
-    binary-install: ^0.1.0
-  bin:
-    wasm-pack: run.js
-  checksum: 18ff3bf91fdafbe24570665ca761d1a90f264e902ac6c05b5dae0ba64622ce4c64488dfa89093f958cb6edfa77a1d30659cf69977a1eba8ce0c250ba4a896f58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
we are getting issues with `yarn pack` and `yarn build` using wasm-pack 0.10.2