### PR TITLE
[Merged by Bors] - feature/267-wasm-console-log

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,9 +7,7 @@ import("../pkg").then(async fluvioWasm => {
       await Fluvio.setupDebugging(false, 'Info');
       const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
-      console.log(`Creating topic ${topic}`);
       await admin.createTopic(topic, 1);
-      console.log(`Created topic ${topic}`);
 
       const producer = await fluvio.topicProducer(topic);
       await producer.send("", `count`);

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ import("../pkg").then(async fluvioWasm => {
   while (true) {
     let topic = createUUID();
     try {
-      await Fluvio.setupDebugging(false, 'Info');
+      Fluvio.setupDebugging(false, 'Info');
       const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
       await admin.createTopic(topic, 1);

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ import("../pkg").then(async fluvioWasm => {
   while (true) {
     let topic = createUUID();
     try {
-      Fluvio.setupDebugging(false, 'Info');
+      Fluvio.setupDebugging(false, 'Debug');
       const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
       await admin.createTopic(topic, 1);

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,8 @@ import("../pkg").then(async fluvioWasm => {
   while (true) {
     let topic = createUUID();
     try {
-      const fluvio = await Fluvio.connect("ws://localhost:3000")
+      await Fluvio.setupDebugging('Error');
+      const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
       console.log(`Creating topic ${topic}`);
       await admin.createTopic(topic, 1);

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ import("../pkg").then(async fluvioWasm => {
   while (true) {
     let topic = createUUID();
     try {
-      await Fluvio.setupDebugging('Error');
+      await Fluvio.setupDebugging(false, 'Info');
       const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
       console.log(`Creating topic ${topic}`);

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -104,7 +104,7 @@ pub enum JsLevel {
     Warn = "Warn",
     Info = "Info",
     Debug = "Debug",
-    Trace = "Trace"
+    Trace = "Trace",
 }
 
 impl Into<Option<Level>> for JsLevel {
@@ -115,7 +115,7 @@ impl Into<Option<Level>> for JsLevel {
             Self::Info => Some(Level::Info),
             Self::Debug => Some(Level::Debug),
             Self::Trace => Some(Level::Trace),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -134,7 +134,8 @@ impl Fluvio {
         let promise = future_to_promise(async move {
             info!("Producing topic: {:#?}", &topic);
 
-            let result = rc.topic_producer(&topic)
+            let result = rc
+                .topic_producer(&topic)
                 .await
                 .map(|producer| JsValue::from(TopicProducer::from(producer)))
                 .map_err(|e| (FluvioError::from(e).into()))

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -97,7 +97,7 @@ pub struct Fluvio {
     inner: Rc<NativeFluvio>,
 }
 
-#[wasm_bindgen(typescript_type = "string | undefined sdfsdfsd")]
+#[wasm_bindgen(typescript_type = "None | Error | Warn | Info | Debug | Trace")]
 #[derive(Debug, Copy, Clone)]
 pub enum JsLevel {
     None = "None",

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -97,10 +97,10 @@ pub struct Fluvio {
     inner: Rc<NativeFluvio>,
 }
 
-#[wasm_bindgen(typescript_type = "None | Error | Warn | Info | Debug | Trace")]
+#[wasm_bindgen(typescript_type = "Error | Warn | Info | Debug | Trace")]
 #[derive(Debug, Copy, Clone)]
 pub enum JsLevel {
-    None = "None",
+    None = "None", // only used as return to indicate that the function succeeded without using the logging level
     Error = "Error",
     Warn = "Warn",
     Info = "Info",
@@ -118,7 +118,7 @@ impl TryInto<Level> for JsLevel {
             Self::Info => Ok(Level::Info),
             Self::Debug => Ok(Level::Debug),
             Self::Trace => Ok(Level::Trace),
-            _ => Err(JsValue::from_str("Wrong string given as JsLevel.")),
+            _ => Err(JsValue::from_str("The level string should be Error | Warn | Info | Debug | Trace")),
         }
     }
 }
@@ -131,14 +131,14 @@ impl Fluvio {
         let rc = self.inner.clone();
 
         let promise = future_to_promise(async move {
-            info!("Producing topic: {:#?}", &topic);
+            info!("Creating producer for topic {}", topic);
 
             rc.topic_producer(&topic)
                 .await
                 .map(|producer| JsValue::from(TopicProducer::from(producer)))
                 .map_err(|e| (FluvioError::from(e).into()))
                 .map(|r| {
-                    info!("Produced topic: {:#?}", &topic);
+                    info!("Created producer for topic {}", topic);
                     r
                 })
         });

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -97,10 +97,13 @@ pub struct Fluvio {
     inner: Rc<NativeFluvio>,
 }
 
-#[wasm_bindgen(typescript_type = "Error | Warn | Info | Debug | Trace")]
+#[allow(clippy::manual_non_exhaustive)]
+#[wasm_bindgen(typescript_type = "'Error' | 'Warn' | 'Info' | 'Debug' | 'Trace'")]
 #[derive(Debug, Copy, Clone)]
 pub enum JsLevel {
-    None = "None", // only used as return to indicate that the function succeeded without using the logging level
+    // None is only used as return,
+    // to indicate that the function succeeded without using the logging level.
+    None = "None",
     Error = "Error",
     Warn = "Warn",
     Info = "Info",
@@ -118,7 +121,9 @@ impl TryInto<Level> for JsLevel {
             Self::Info => Ok(Level::Info),
             Self::Debug => Ok(Level::Debug),
             Self::Trace => Ok(Level::Trace),
-            _ => Err(JsValue::from_str("The level string should be Error | Warn | Info | Debug | Trace")),
+            _ => Err(JsValue::from_str(
+                "The level string should be Error | Warn | Info | Debug | Trace",
+            )),
         }
     }
 }
@@ -135,12 +140,11 @@ impl Fluvio {
 
             rc.topic_producer(&topic)
                 .await
-                .map(|producer| JsValue::from(TopicProducer::from(producer)))
-                .map_err(|e| (FluvioError::from(e).into()))
-                .map(|r| {
+                .map(|producer| {
                     info!("Created producer for topic {}", topic);
-                    r
+                    JsValue::from(TopicProducer::from(producer))
                 })
+                .map_err(|e| (FluvioError::from(e).into()))
         });
 
         // WARNING: this does not validate the return type. Check carefully.
@@ -198,7 +202,7 @@ impl Fluvio {
 
     /// Connects to fluvio server
     pub async fn connect(addr: String) -> Result<Fluvio, wasm_bindgen::JsValue> {
-        Self::setup_debugging(false, None);
+        let _ = Self::setup_debugging(false, None);
 
         let config = FluvioConfig::new(addr.clone());
 
@@ -246,9 +250,7 @@ impl Fluvio {
         use std::sync::Once;
         static START: Once = Once::new();
 
-        if level.is_some() {
-            let level = level.unwrap();
-
+        if let Some(level) = level {
             let result = level;
 
             let level: Level = level.try_into()?;

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -15,7 +15,7 @@ use crate::{
     PartitionConsumer, TopicProducer,
 };
 
-use log::{debug, Level};
+use log::{debug, info, Level};
 
 #[wasm_bindgen(typescript_custom_section)]
 const PRODUCER_CONFIG_TYPE: &str = r#"
@@ -217,7 +217,7 @@ impl Fluvio {
             .map_err(FluvioError::from)?,
         );
 
-        debug!("Connected to fluvio server at {}", addr_str);
+        info!("Connected to fluvio server at {}", addr_str);
 
         Ok(Self { inner })
     }

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -15,7 +15,7 @@ use crate::{
     PartitionConsumer, TopicProducer,
 };
 
-use log::{info, Level};
+use log::{debug, Level};
 
 #[wasm_bindgen(typescript_custom_section)]
 const PRODUCER_CONFIG_TYPE: &str = r#"
@@ -136,12 +136,12 @@ impl Fluvio {
         let rc = self.inner.clone();
 
         let promise = future_to_promise(async move {
-            info!("Creating producer for topic {}", topic);
+            debug!("Creating producer for topic {}", topic);
 
             rc.topic_producer(&topic)
                 .await
                 .map(|producer| {
-                    info!("Created producer for topic {}", topic);
+                    debug!("Created producer for topic {}", topic);
                     JsValue::from(TopicProducer::from(producer))
                 })
                 .map_err(|e| (FluvioError::from(e).into()))
@@ -217,7 +217,7 @@ impl Fluvio {
             .map_err(FluvioError::from)?,
         );
 
-        info!("Connected to fluvio server at {}", addr_str);
+        debug!("Connected to fluvio server at {}", addr_str);
 
         Ok(Self { inner })
     }

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -137,9 +137,9 @@ impl Fluvio {
                 .await
                 .map(|producer| JsValue::from(TopicProducer::from(producer)))
                 .map_err(|e| (FluvioError::from(e).into()))
-                .and_then(|r| {
+                .map(|r| {
                     info!("Produced topic: {:#?}", &topic);
-                    Ok(r)
+                    r
                 })
         });
 


### PR DESCRIPTION
I added a proper logging level logger implementation that is callable from JS.
`Example: Fluvio.setupDebugging(false, 'Info');`
Where the first argument is the full WASM logging of **EVERYTHING** and the second argument is the logging level for **fluvio-client-wasm** itself. Employ macros such as _info!_ to make use of it.

The logging levels:
`
pub enum JsLevel {
    Error = "Error",
    Warn = "Warn",
    Info = "Info",
    Debug = "Debug",
    Trace = "Trace"
}
`

Resolves #267