### PR TITLE
[Merged by Bors] - feat: expose `Fluvio::platform_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## About
+
 This is the browser wasm client for
 [fluvio](https://github.com/infinyon/fluvio). This is meant to be used via
 javascript in a web browser.
@@ -15,6 +16,7 @@ following:
 * `make run-fluvio-websocket-proxy`
 
 ### Hot Reloading
+
 To use hotreloading for the contents of
 [`js/index.js`](https://github.com/infinyon/fluvio-client-wasm/blob/main/js/index.js)
 * `make webpack-dev`
@@ -22,5 +24,8 @@ To use hotreloading for the contents of
 Now go edit `js/index.js` to try your work.
 
 ### Rust Tests
+
+Integration tests are defined in the `tests` directory.
+
 * `make run-fluvio-websocket-proxy` in one terminal.
 * `make test`  will run the rust tests in a headless browser.

--- a/js/index.js
+++ b/js/index.js
@@ -7,6 +7,7 @@ import("../pkg").then(async fluvioWasm => {
       Fluvio.setupDebugging(false, 'Debug');
       const fluvio = await Fluvio.connect("ws://localhost:3000");
       const admin = await fluvio.admin();
+      console.log(`Using Fluvio Cluster Version: ${fluvio.platformVersion()}`);
       await admin.createTopic(topic, 1);
 
       const producer = await fluvio.topicProducer(topic);

--- a/src/fluvio.rs
+++ b/src/fluvio.rs
@@ -270,4 +270,12 @@ impl Fluvio {
             Ok(JsLevel::None)
         }
     }
+
+    /// Retrieves the underlying Fluvio `platform_version`
+    ///
+    /// Refer: https://docs.rs/fluvio/latest/fluvio/struct.Fluvio.html#method.platform_version
+    #[wasm_bindgen(js_name = platformVersion)]
+    pub fn platform_version(&self) -> String {
+        self.inner.platform_version().to_string()
+    }
 }

--- a/tests/js/simple/simple.js
+++ b/tests/js/simple/simple.js
@@ -32,6 +32,7 @@ export const test = async () => {
     compression,
   };
 
+  console.log(`Using Fluvio Cluster Version: ${fluvio.platformVersion()}`);
   const producer = await fluvio.topicProducerWithConfig(topic, config);
   await producer.send("", `count`);
   const offset = Offset.beginning();


### PR DESCRIPTION
Provides support to retrieve Fluvio's cluster version.

Resolves: https://github.com/infinyon/fluvio-client-wasm/issues/134